### PR TITLE
Specify virtualbox provider

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,7 +60,7 @@ sed -i "" -e "s#documentroot => \"\"#documentroot => \"$DOCROOT\"#g" puppet/mani
 
 # Build VM.
 vagrant destroy --force
-vagrant up
+vagrant up --provider=virtualbox
 
 # Run custom script inside the virtual machine.
 PORT=`vagrant ssh-config | grep Port | grep -o '[0-9]\+'`


### PR DESCRIPTION
On systems where virtualbox is not the default, the install fails. The change specifies virtualbox provider explicitly. Fix #3
